### PR TITLE
fix(tiny-pro): if role id is undefined will send empty array not [null]

### DIFF
--- a/template/tinyvue/src/utils/is.ts
+++ b/template/tinyvue/src/utils/is.ts
@@ -1,0 +1,1 @@
+export const isUndefined = (val: unknown): val is undefined => val === undefined;

--- a/template/tinyvue/src/views/userManager/info/components/info-tab.vue
+++ b/template/tinyvue/src/views/userManager/info/components/info-tab.vue
@@ -416,6 +416,7 @@
   import { getSimpleDate } from '@/utils/time';
   import { getAllRole } from '@/api/role';
   import { FilterType } from '@/types/global';
+  import { isUndefined } from '@/utils/is';
   import UserAdd from '../../useradd/index.vue';
   import UserDetail from '../../user-detail/index.vue';
 
@@ -697,7 +698,7 @@
         name: data.name,
         address: data.address,
         department: data.department,
-        roleIds: [data.role[0]?.id],
+        roleIds: isUndefined(data.role[0]?.id) ? [] : [data.role[0]?.id],
         employeeType: data.employeeType,
         probationDuration: data.probationDuration,
         probationStart: data.probationStart,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

原先的逻辑是, 如果创建了一个角色为空的用户, 那么修改任何一个值的时候都会去读取 role[0].id. 但因为这个用户没有任何的角色, id是null或者undefined.

Issue Number: N/A

## What is the new behavior?

现在创建一个角色为空的用户，那么修改任何一个值的时候，如果role[0].id是undefined,那么会直接替换成一个空数组而不是数组里第一项为null

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User Manager: Updating a user with no role selected now sends an empty role list rather than an invalid value, preventing save errors and backend validation failures. This improves data integrity and ensures smoother profile updates when roles are optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->