### PR TITLE
fix(web): if not batch-remove permission should not display i18n or user batch-remove button

### DIFF
--- a/template/tinyvue/src/views/locale/components/add-locale.vue
+++ b/template/tinyvue/src/views/locale/components/add-locale.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <tiny-button show-footer type="primary" @click="onOpen" round>
+    <tiny-button show-footer type="primary" round @click="onOpen">
       {{ $t('locale.add.btn') }}
     </tiny-button>
-    <tiny-button round @click="onBatchRemove">
+    <tiny-button v-permission="'i18n::batch-remove'" round @click="onBatchRemove">
       {{ $t('locale.batchRemove') }}
     </tiny-button>
     <tiny-dialog-box
@@ -68,8 +68,8 @@
           size="small"
           :text="$t('locale.add.btn')"
           type="primary"
-          @click="addLocale"
           round
+          @click="addLocale"
         ></tiny-button>
       </template>
     </tiny-dialog-box>
@@ -123,8 +123,8 @@
   const lang = reactive({ name: '' });
 
   const onBatchRemove = () => {
-    
-    emits('batchRemove') 
+
+    emits('batchRemove')
   }
 
   const rules = {

--- a/template/tinyvue/src/views/userManager/info/components/info-tab.vue
+++ b/template/tinyvue/src/views/userManager/info/components/info-tab.vue
@@ -10,6 +10,7 @@
           >{{ $t('userInfo.modal.title.add') }}
         </tiny-button>
         <tiny-button
+          v-permission="'user::batch-remove'"
           round
           @click="handleBatchDeleteUser"
           >{{ $t('locale.batchRemove') }}


### PR DESCRIPTION
# PR

请位于 #89 之后合并. 该PR解决了如果没有批量删除权限则不显示批量删除按钮的问题

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

如果用户没有 `batch-remove` 权限也会显示 `i18n` 或 `user` 批量删除

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

如果用户没有 `batch-remove` 权限将**不会**显示 `i18n` 或 `user` 批量删除

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Batch Remove is now permission-gated in Locale and User Manager tabs. Only users with the appropriate permissions can see and use the bulk delete action, improving access control and reducing accidental mass operations.
  - No changes to the underlying delete behavior; only button visibility/availability is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->