### PR TITLE
fix(web): role table pager

### DIFF
--- a/template/tinyvue/src/types/global.ts
+++ b/template/tinyvue/src/types/global.ts
@@ -24,6 +24,7 @@ export type Pager = {
   layout: string;
   total: number;
   pageSize: number;
+  align?: 'left' | 'center' | 'right'
 };
 
 export interface AnyObject {

--- a/template/tinyvue/src/views/role/info/components/info-tab.vue
+++ b/template/tinyvue/src/views/role/info/components/info-tab.vue
@@ -60,16 +60,15 @@
     permissions.value = data;
   });
   const pagerConfig = ref<{
-    component: any;
-    attrs: Pager;
+    attrs:Pager,
   }>({
-    component: TinyPager,
     attrs: {
       currentPage: 1,
       pageSize: 5,
-      pageSizes: [10, 20, 50, 100],
+      pageSizes: [5, 10, 20, 50, 100],
       total: 0,
-      layout: 'sizes, total, prev, pager, next, jumper',
+      align: 'right',
+      layout: 'total, sizes, prev, pager, next, jumper'
     },
   });
   const roleTableRef = ref();
@@ -99,7 +98,7 @@
             data.roleInfo.items.forEach((item,index) => {
                 tableData.value[index].permissionIds = [];
                 item.permission.forEach((item1) => {
-                  tableData.value[index].permissionIds.push(item1.id) 
+                  tableData.value[index].permissionIds.push(item1.id)
                 });
             });
             resolve({

--- a/template/tinyvue/src/views/role/info/components/info-tab.vue
+++ b/template/tinyvue/src/views/role/info/components/info-tab.vue
@@ -64,8 +64,8 @@
   }>({
     attrs: {
       currentPage: 1,
-      pageSize: 5,
-      pageSizes: [5, 10, 20, 50, 100],
+      pageSize: 10,
+      pageSizes: [10, 20, 50, 100],
       total: 0,
       align: 'right',
       layout: 'total, sizes, prev, pager, next, jumper'

--- a/template/tinyvue/src/views/role/info/components/role-table.vue
+++ b/template/tinyvue/src/views/role/info/components/role-table.vue
@@ -24,7 +24,6 @@
     };
     permissions: Permission[];
     pagerConfig: {
-      component: any;
       attrs: Pager;
     };
     filter: any;


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

最初情况, page-size 默认为5个/页, 但`pageSizes`最小为10个/页. 导致如果添加到第6个角色的时候会不显示, 必须先切换到 20个/页 然后且回到 10个/页 才能正常工作

Issue Number: N/A

## What is the new behavior?

page-size默认为10个/页

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pager now supports alignment options (left, center, right); default set to right in Role Info view.
  - Updated pager defaults: page size increased to 10 and layout reordered to show total first.
- Refactor
  - Simplified pager configuration across role-related views to rely on default components and cleaner props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->