### PR TITLE
fix: fix unocss presetAttributify invalid after built

### DIFF
--- a/template/tinyvue/src/layout/default-layout.vue
+++ b/template/tinyvue/src/layout/default-layout.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="layout">
     <div>
-      <div relative class="shadow-[0_4px_6px_#0003] z-[999]">
+      <div class="relative shadow-[0_4px_6px_#0003] z-[999]">
         <NavBar v-if="layoutMode[myPattern].navbar"/>
       </div>
-      <div flex>
+      <div class="flex">
         <Suspense>
           <Menu v-if="reloadKey !== 'menu' && layoutMode[myPattern].menu" class="shadow-[0_4px_12px_#0000001a] z-[100]" />
         </Suspense>


### PR DESCRIPTION
# PR

构建之后，presetAttributify 风格的样式丢失。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized layout markup by replacing boolean-like utility attributes with class-based equivalents for consistency. Consolidates positioning and layout utilities into class lists. No visual or functional changes expected.

- Refactor
  - Minor cleanup of the default layout template to align with styling conventions and improve maintainability. No impact on control flow, data handling, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->