### PR TITLE
perf(token): optimize lock and imple reentrancy

### DIFF
--- a/template/nestJs/libs/locker/src/index.ts
+++ b/template/nestJs/libs/locker/src/index.ts
@@ -1,2 +1,5 @@
 export * from './locker.module';
 export * from './locker.service';
+export * from './locker.discover';
+export * from './request-context.service';
+export * from './request-context.middleware';

--- a/template/nestJs/libs/locker/src/locker.discover.ts
+++ b/template/nestJs/libs/locker/src/locker.discover.ts
@@ -1,0 +1,21 @@
+// service-locator.ts
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+
+@Injectable()
+export class LockerDiscover implements OnModuleInit {
+  private static moduleRef: ModuleRef;
+
+  constructor(private readonly moduleRef: ModuleRef) {}
+
+  onModuleInit() {
+    LockerDiscover.moduleRef = this.moduleRef;
+  }
+
+  static get<T>(type: new (...args: any[]) => T): T {
+    if (!LockerDiscover.moduleRef) {
+      throw new Error('ServiceLocator not initialized');
+    }
+    return LockerDiscover.moduleRef.get(type, { strict: false });
+  }
+}

--- a/template/nestJs/libs/locker/src/locker.service.ts
+++ b/template/nestJs/libs/locker/src/locker.service.ts
@@ -6,101 +6,275 @@ import { hostname } from 'os';
 @Injectable({ scope: Scope.DEFAULT })
 export class LockerService {
   private readonly logger = new Logger(LockerService.name);
+
   private readonly LOCK_PREFIX = 'lock:';
-  private readonly DEFAULT_TTL = 30000; // 30秒默认超时
-  private readonly RETRY_DELAY = 1000;   // 重试间隔
-  private readonly MAX_RETRY = 20;       // 最大重试次数
-  private readonly id = `${process.pid}-${hostname()}-${randomBytes(16).toString('hex')}`;
+  private readonly LOCK_COUNT_SUFFIX = ':count';
+  private readonly DEFAULT_TTL = 30000;
+  private readonly RETRY_DELAY = 100;
+  private readonly MAX_RETRY = 100;
+
+  private readonly processId = `${process.pid}-${hostname()}-${randomBytes(16).toString('hex')}`;
 
   constructor(private readonly redisService: RedisService) {}
 
-  async acquire(key: string, ttl: number = this.DEFAULT_TTL): Promise<boolean> {
-    const lockKey = `${this.LOCK_PREFIX}${key}`;
-
-    try {
-      const result = await this.redisService.getRedis().set(
-        lockKey,
-        this.id,
-        'PX',
-        ttl,
-        'NX' // Only set if key doesn't exist
-      );
-
-      return result === 'OK';
-    } catch (error) {
-      this.logger.error(`Failed to acquire lock for key ${key}: ${error.message}`);
-      return false;
-    }
+  private getLockKeys(key: string): { lockKey: string; countKey: string } {
+    const baseKey = `${this.LOCK_PREFIX}{${key}}`;
+    return {
+      lockKey: baseKey,
+      countKey: `${baseKey}${this.LOCK_COUNT_SUFFIX}`,
+    };
   }
 
-  async release(key: string): Promise<boolean> {
-    const lockKey = `${this.LOCK_PREFIX}${key}`;
+  async acquire(key: string, ttl: number = this.DEFAULT_TTL, requestId?: string): Promise<boolean> {
+    const redis = this.redisService.getRedis();
+    const { lockKey, countKey } = this.getLockKeys(key);
+    const fullId = this.getFullId(requestId);
+
     const luaScript = `
-      if redis.call("get", KEYS[1]) == ARGV[1] then
-        return redis.call("del", KEYS[1])
+      local lockKey = KEYS[1]
+      local countKey = KEYS[2]
+      local fullId = ARGV[1]
+      local ttl = tonumber(ARGV[2])
+
+      local currentHolder = redis.call('GET', lockKey)
+
+      if currentHolder == fullId then
+        local count = redis.call('HINCRBY', countKey, fullId, 1)
+        redis.call('PEXPIRE', lockKey, ttl)
+        redis.call('PEXPIRE', countKey, ttl)
+        return count
+      elseif currentHolder == false then
+        redis.call('SET', lockKey, fullId, 'PX', ttl)
+        redis.call('HSET', countKey, fullId, 1)
+        redis.call('PEXPIRE', countKey, ttl)
+        return 1
       else
         return 0
       end
     `;
 
     try {
-      const result = await this.redisService.getRedis().eval(
+      const result = (await redis.eval(
         luaScript,
-        1,
+        2,
         lockKey,
-        this.id
-      );
+        countKey,
+        fullId,
+        ttl.toString(),
+      )) as number;
 
-      return result === 1;
+      if (result > 0) {
+        this.logger.debug(`Lock acquired/reentered [${key}], requestId: ${requestId}, count: ${result}`);
+        return true;
+      }
+      return false;
     } catch (error) {
-      this.logger.error(`Failed to release lock for key ${key}: ${error.message}`);
+      this.logger.error(`Acquire lock error [${key}]: ${error.message}`);
       return false;
     }
   }
 
-  async extend(key: string, ttl: number): Promise<boolean> {
-    const lockKey = `${this.LOCK_PREFIX}${key}`;
+  async release(key: string, requestId?: string, ttl?: number): Promise<boolean> {
+    const redis = this.redisService.getRedis();
+    const { lockKey, countKey } = this.getLockKeys(key);
+    const fullId = this.getFullId(requestId);
+    const actualTtl = ttl || this.DEFAULT_TTL;
 
-      const luaScript = `
-        if redis.call("get", KEYS[1]) == ARGV[1] then
-          return redis.call("pexpire", KEYS[1], ARGV[2])
-        else
-          return 0
+    // ✅ 修复：更安全的 countKey 删除逻辑
+    const luaScript = `
+      local lockKey = KEYS[1]
+      local countKey = KEYS[2]
+      local fullId = ARGV[1]
+      local ttl = tonumber(ARGV[2])
+
+      if redis.call('GET', lockKey) ~= fullId then
+        return 0
+      end
+
+      local count = redis.call('HINCRBY', countKey, fullId, -1)
+
+      if count <= 0 then
+        redis.call('DEL', lockKey)
+        redis.call('HDEL', countKey, fullId)
+        if redis.call('HLEN', countKey) == 0 then
+          redis.call('DEL', countKey)
         end
-      `;
+        return 1
+      else
+        redis.call('PEXPIRE', lockKey, ttl)
+        redis.call('PEXPIRE', countKey, ttl)
+        return 2
+      end
+    `;
 
-      try {
-        const result = await this.redisService.getRedis().eval(
-          luaScript,
-          1,
-          lockKey,
-          this.id, // 使用固定的实例ID进行验证
-          ttl.toString()
-        );
+    try {
+      const result = (await redis.eval(
+        luaScript,
+        2,
+        lockKey,
+        countKey,
+        fullId,
+        actualTtl.toString(),
+      )) as number;
 
-        return result === 1;
-      } catch (error) {
-        this.logger.error(`Failed to extend lock for key ${key}: ${error.message}`);
+      if (result === 0) {
+        this.logger.warn(`Release failed: Not holder of [${key}], requestId: ${requestId}`);
         return false;
+      } else if (result === 1) {
+        this.logger.debug(`Lock fully released [${key}], requestId: ${requestId}`);
+      } else {
+        this.logger.debug(`Lock reentry decreased [${key}], requestId: ${requestId}`);
       }
+      return true;
+    } catch (error) {
+      this.logger.error(`Release lock error [${key}]: ${error.message}`);
+      return false;
+    }
   }
 
+  // ✅ 修复：添加耗时监控和动态调整
+  async acquireWithAutoRenew(
+    key: string,
+    ttl: number = this.DEFAULT_TTL,
+    maxRetries: number = this.MAX_RETRY,
+    requestId?: string,
+  ): Promise<() => Promise<void>> {
+    const acquired = await this.acquireWithRetry(key, ttl, maxRetries, requestId);
+
+    if (!acquired) {
+      throw new Error(`Failed to acquire lock for [${key}] after ${maxRetries} retries`);
+    }
+
+    let isRenewing = true;
+    let consecutiveFailures = 0;
+    let lastRenewalDuration = 0;
+    let totalRenewals = 0;
+    const maxConsecutiveFailures = 3;
+
+    const scheduleNextRenewal = () => {
+      if (!isRenewing) return;
+
+      // ✅ 修复：动态调整续期间隔
+      const baseInterval = ttl / 3;
+      const adjustedInterval = Math.max(
+        baseInterval - lastRenewalDuration * 1.5,
+        ttl / 10,
+      );
+
+      setTimeout(async () => {
+        if (!isRenewing) return;
+
+        const startTime = Date.now();
+
+        try {
+          const extended = await this.extend(key, ttl, requestId);
+          const duration = Date.now() - startTime;
+          lastRenewalDuration = duration;
+
+          if (extended) {
+            consecutiveFailures = 0;
+            totalRenewals++;
+
+            // ✅ 添加：监控续期耗时
+            const percentage = (duration / ttl * 100).toFixed(1);
+            if (duration > ttl / 4) {
+              this.logger.warn(
+                `Slow renewal for [${key}]: ${duration}ms (${percentage}% of TTL)`
+              );
+            } else {
+              this.logger.debug(
+                `Renewed [${key}], duration: ${duration}ms, total: ${totalRenewals}`
+              );
+            }
+
+            scheduleNextRenewal();
+          } else {
+            throw new Error('Lock lost during renewal');
+          }
+        } catch (error) {
+          consecutiveFailures++;
+          this.logger.error(
+            `Renewal error for [${key}]: ${error.message}, ` +
+            `failures: ${consecutiveFailures}/${maxConsecutiveFailures}`
+          );
+
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            isRenewing = false;
+            this.logger.error(
+              `Auto-renewal stopped for [${key}] after ${consecutiveFailures} failures`
+            );
+          } else {
+            scheduleNextRenewal();
+          }
+        }
+      }, adjustedInterval);
+    };
+
+    scheduleNextRenewal();
+
+    return async () => {
+      isRenewing = false;
+      this.logger.debug(
+        `Releasing [${key}], ${totalRenewals} renewals, ${consecutiveFailures} failures`
+      );
+      await this.release(key, requestId, ttl);
+    };
+  }
+
+  async acquireWithRetry(
+    key: string,
+    ttl: number = this.DEFAULT_TTL,
+    maxRetries: number = this.MAX_RETRY,
+    requestId?: string,
+  ): Promise<boolean> {
+    for (let i = 0; i < maxRetries; i++) {
+      if (await this.acquire(key, ttl, requestId)) return true;
+      await new Promise((resolve) => setTimeout(resolve, this.RETRY_DELAY));
+    }
+    this.logger.warn(`Failed to acquire lock for [${key}] after ${maxRetries} retries`);
+    return false;
+  }
+
+  async extend(key: string, ttl: number, requestId?: string): Promise<boolean> {
+    const redis = this.redisService.getRedis();
+    const { lockKey, countKey } = this.getLockKeys(key);
+    const fullId = this.getFullId(requestId);
+
+    const luaScript = `
+      if redis.call('GET', KEYS[1]) == ARGV[1] then
+        redis.call('PEXPIRE', KEYS[1], ARGV[2])
+        redis.call('PEXPIRE', KEYS[2], ARGV[2])
+        return 1
+      end
+      return 0
+    `;
+
+    try {
+      const result = await redis.eval(luaScript, 2, lockKey, countKey, fullId, ttl.toString());
+      return result === 1;
+    } catch (error) {
+      this.logger.error(`Extend lock error [${key}]: ${error.message}`);
+      return false;
+    }
+  }
+
+  // ✅ 添加：辅助方法
   async isLocked(key: string): Promise<boolean> {
-    const lockKey = `${this.LOCK_PREFIX}${key}`;
+    const { lockKey } = this.getLockKeys(key);
     const result = await this.redisService.getRedis().exists(lockKey);
     return result === 1;
   }
 
-  async acquireWithRetry(key: string, ttl?: number, maxRetries: number = this.MAX_RETRY): Promise<boolean> {
-    for (let i = 0; i < maxRetries; i++) {
-      const acquired = await this.acquire(key, ttl);
-      if (acquired) {
-        return true
-      };
+  async getReentryCount(key: string, requestId?: string): Promise<number> {
+    const redis = this.redisService.getRedis();
+    const { countKey } = this.getLockKeys(key);
+    const fullId = this.getFullId(requestId);
 
-      // Wait before retrying
-      await new Promise(resolve => setTimeout(resolve, this.RETRY_DELAY));
-    }
-    return false;
+    const count = await redis.hget(countKey, fullId);
+    return count ? parseInt(count) : 0;
+  }
+
+  private getFullId(requestId?: string): string {
+    return requestId ? `${this.processId}:${requestId}` : this.processId;
   }
 }

--- a/template/nestJs/libs/locker/src/request-context.middleware.ts
+++ b/template/nestJs/libs/locker/src/request-context.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { LockRequestContextService } from './request-context.service';
+
+@Injectable()
+export class LockRequestContextMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    LockRequestContextService.run(() => {
+      next();
+    });
+  }
+}

--- a/template/nestJs/libs/locker/src/request-context.service.ts
+++ b/template/nestJs/libs/locker/src/request-context.service.ts
@@ -1,0 +1,28 @@
+// libs/locker/src/request-context.service.ts
+import { AsyncLocalStorage } from 'async_hooks';
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface RequestContext {
+  requestId: string;
+}
+
+@Injectable()
+export class LockRequestContextService {
+  private static als = new AsyncLocalStorage<RequestContext>();
+
+  static run<T>(callback: () => T): T {
+    const context: RequestContext = {
+      requestId: randomUUID(),
+    };
+    return this.als.run(context, callback);
+  }
+
+  static getRequestId(): string | undefined {
+    return this.als.getStore()?.requestId;
+  }
+
+  static getContext(): RequestContext | undefined {
+    return this.als.getStore();
+  }
+}

--- a/template/nestJs/libs/locker/src/with-lock.decorator.ts
+++ b/template/nestJs/libs/locker/src/with-lock.decorator.ts
@@ -2,52 +2,73 @@ import { LockerService } from './locker.service';
 import { I18nTranslations } from '../../../src/.generate/i18n.generated';
 import { I18nContext, I18nService } from 'nestjs-i18n';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { LockerDiscover } from './locker.discover';
+import { LockRequestContextService } from './request-context.service';
 
-export type WithLockOptions =  {
-  key: string | ((args: any[]) => string);
+export type WithLockOptions = {
+  key: string | ((args: any[], context?: any) => string);
   ttl?: number;
-} & ({
-  service: string;
-  method: string;
-} | {
-  paramIndex?: number;
-});
+  autoRenew?: boolean;
+};
 
 export function WithLock(options: WithLockOptions) {
   return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
 
     descriptor.value = async function (...args: any[]) {
-      const locker: LockerService = 'service' in options ? this[options.service] || this.locker : this.locker;
-      const i18: I18nService<I18nTranslations> = this.i18nService || this.i18n;
-      if (!locker) {
-        throw new HttpException(i18.t('exception.common.internalError', {
-            lang: I18nContext.current().lang,
-        }), HttpStatus.INTERNAL_SERVER_ERROR)
-      }
+      const locker = LockerDiscover.get(LockerService);
+      const i18n = LockerDiscover.get<I18nService<I18nTranslations>>(I18nService);
 
+      // 生成锁 key
       let lockKey: string;
       if (typeof options.key === 'function') {
-        lockKey = options.key(args);
-      } else if ('paramIndex' in options && options.paramIndex !== undefined) {
-        lockKey = `${options.key}:${args[options.paramIndex]}`;
+        lockKey = options.key.call(this, args, this);
       } else {
         lockKey = options.key;
       }
 
       const ttl = options.ttl || 30000;
 
-      const acquired = await locker.acquireWithRetry(lockKey, ttl);
-      if (!acquired) {
-        throw new HttpException(i18.t('exception.common.timeout', {
-          lang: I18nContext.current().lang,
-        }), HttpStatus.REQUEST_TIMEOUT)
+      // 获取请求ID（用于可重入锁）
+      const requestId = LockRequestContextService.getRequestId();
+
+      let releaseLock: (() => Promise<void>) | null = null;
+
+      try {
+        if (options.autoRenew) {
+          // 使用自动续期的锁
+          releaseLock = await locker.acquireWithAutoRenew(lockKey, ttl, 100, requestId);
+        } else {
+          // 普通锁
+          const acquired = await locker.acquireWithRetry(lockKey, ttl, 100, requestId);
+          if (!acquired) {
+            const lang = I18nContext.current()?.lang || 'en';
+            throw new HttpException(
+              i18n?.t('exception.common.timeout', { lang }) || 'Request timeout',
+              HttpStatus.REQUEST_TIMEOUT
+            );
+          }
+          releaseLock = async () => {
+            await locker.release(lockKey, requestId);
+          };
+        }
+      } catch (error) {
+        if (error instanceof HttpException) {
+          throw error;
+        }
+        const lang = I18nContext.current()?.lang || 'en';
+        throw new HttpException(
+          i18n?.t('exception.common.timeout', { lang }) || 'Request timeout',
+          HttpStatus.REQUEST_TIMEOUT
+        );
       }
 
       try {
         return await originalMethod.apply(this, args);
       } finally {
-        await locker.release(lockKey);
+        if (releaseLock) {
+          await releaseLock();
+        }
       }
     };
 

--- a/template/nestJs/src/app.module.ts
+++ b/template/nestJs/src/app.module.ts
@@ -1,7 +1,9 @@
 import {
   HttpException,
   Logger,
+  MiddlewareConsumer,
   Module,
+  NestModule,
   OnModuleInit,
 } from '@nestjs/common';
 import { UserModule } from './user/user.module';
@@ -14,10 +16,7 @@ import { PermissionGuard } from './permission/permission.guard';
 import { RoleModule } from './role/role.module';
 import { join } from 'path';
 import { readFileSync } from 'fs';
-import { UserService } from './user/user.service';
-import { RoleService } from './role/role.service';
-import { PermissionService } from './permission/permission.service';
-import { MenuService } from './menu/menu.service';
+
 import { MenuModule } from './menu/menu.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { I18Module } from './i18/i18.module';
@@ -31,13 +30,12 @@ import { MockModule } from './mock/mock.module';
 import { RejectRequestGuard } from './public/reject.guard';
 import { HealthCheckController } from './health-check.controller';
 import { ApplicationModule } from './application/application.module';
-import { ApplicationService } from './application/application.service';
 import { CONFIG_SCHEMA, Configure } from './config-schema';
 import { InstallLock } from './install-lock';
 import { RedisService } from '../libs/redis/redis.service';
 import Redis from 'ioredis';
 import { RedisModule } from '../libs/redis/redis.module';
-import { LockerModule } from '@app/locker';
+import { LockerModule,LockerDiscover, LockRequestContextMiddleware } from '@app/locker';
 import { MenuInitializer } from './menu/menu.initializer';
 import { RoleInit } from './role/role.initializer';
 import { PermissionInit } from './permission/permission.initalizer';
@@ -92,9 +90,11 @@ const MAX_RETRY = 20;
       useClass: PermissionGuard,
     },
     InstallLock,
+    LockerDiscover,
   ],
+  exports: [LockerDiscover]
 })
-export class AppModule implements OnModuleInit {
+export class AppModule implements OnModuleInit,NestModule {
   constructor(
     private lang: I18LangService,
     private i18: I18Service,
@@ -113,7 +113,13 @@ export class AppModule implements OnModuleInit {
   async setIsInstalled(redis: Redis){
     return redis.set(INSTALL_FLAG, '1');
   }
-  async onModuleInit() {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(LockRequestContextMiddleware)
+      .forRoutes('*');
+  }
+  async onModuleInit(
+  ) {
     const IS_PREVIEW_MOD = this.cfg.get('PREVIEW_MODE');
     if (IS_PREVIEW_MOD) {
       Logger.warn('You are currently in demonstration mode. All additions, deletions, and modifications request will be rejected');

--- a/template/nestJs/src/auth/auth.service.ts
+++ b/template/nestJs/src/auth/auth.service.ts
@@ -12,6 +12,7 @@ import { pick } from '../../libs/utils/pick';
 import { JwtService } from '@app/jwt';
 import { ConfigService } from '@nestjs/config';
 import { Configure } from 'src/config-schema';
+import { WithLock } from '@app/locker/with-lock.decorator';
 
 @Injectable()
 export class AuthService {
@@ -42,6 +43,17 @@ export class AuthService {
     }
     return;
   }
+
+  @WithLock({
+    key(args) {
+      let uid = 'unknown';
+      try {
+        const token = this.jwtService.decode(args[0]) as any;
+        uid = token?.id;
+      } catch {}
+      return `user-token:${uid}`;
+    }
+  })
   async refreshToken(
     maybeToken: string
   ){
@@ -65,7 +77,7 @@ export class AuthService {
     if (accessToken){
       await this.tokenService.revokeToken(accessToken);
     }
-    await this.tokenService.revokeToken(refreshToken);
+    await this.tokenService.revokeRefreshToken(refreshToken);
     const tokenPair = await this.tokenService.createToken(id, email);
     // 颁发一个新的token
     // issueToken 内部会在颁发前踢出最老的会话, 也会删除过期的会话, 这里就不用调用 this.tokenService.revokeExpiredToken 了

--- a/template/nestJs/src/auth/token.service.ts
+++ b/template/nestJs/src/auth/token.service.ts
@@ -26,13 +26,12 @@ export class TokenService {
     private redisService: RedisService,
     private jwt: JwtService,
     private cfg: ConfigService,
-    private locker: LockerService,
-    private readonly i18n: I18nService<I18nTranslations>
   ){}
 
   @WithLock({
     key(args){
-      return `lock:revokeToken:${args[0]}`
+      const {id} = this.jwt.decode(args[0]) as AccessTokenPayload;
+      return `user-token:${id}`
     }
   })
   async revokeToken(token: string) {
@@ -46,7 +45,22 @@ export class TokenService {
 
   @WithLock({
     key(args){
-      return `lock:revokeExpiredToken:${args[0]}`
+      const {id} = this.jwt.decode(args[0]) as AccessTokenPayload;
+      return `user-token:${id}`
+    }
+  })
+  async revokeRefreshToken(refreshToken: string) {
+    const {id:uid, jti} = this.jwt.decode<RefreshTokenPayload>(refreshToken);
+    const redis = this.redisService.getRedis();
+    const multi = redis.multi();
+    multi.del(`rt:${uid}:${jti}`);
+    multi.lrem(`user:${uid}:rt`, 0, jti);
+    await multi.exec();
+  }
+
+  @WithLock({
+    key(args){
+      return `user-token:${args[0]}`
     }
   })
   private async revokeExpiredToken(uid: number){
@@ -78,7 +92,7 @@ export class TokenService {
 
   @WithLock({
     key(args){
-      return `lock:revokeByUid:${args[0]}`
+      return `user-token:${args[0]}`
     }
   })
   async revokeByUid(uid: number){
@@ -101,11 +115,6 @@ export class TokenService {
     await multi.exec();
   }
 
-  @WithLock({
-    key(args){
-      return `lock:createToken:${args[0]}:${args[1]}`
-    }
-  })
   async createToken(id: number, email: string): Promise<TokenData>{
     const accessTokenTTLSeconds = this.cfg.get('REDIS_SECONDS') ?? 7200;
     const refreshTokenTTL = this.cfg.get('REFRESH_TOKEN_TTL') // ms;
@@ -147,7 +156,7 @@ export class TokenService {
 
   @WithLock({
     key(args){
-      return `lock:getLastToken:${args[0]}`
+      return `user-token:${args[0]}`
     }
   })
   // 获取最早登陆的Token
@@ -168,11 +177,10 @@ export class TokenService {
     return {accessToken, refreshToken}
 
   }
-  @WithLock({
-    key(args){
-      return `lock:accessTokenAlive:${args[0]}`
-    }
-  })
+
+  // O(N) 的时间复杂度我想应该是可以被接受的.
+  // 这里被AuthGuard调用, 是一个热点路径, exists的复杂度是O(N), N 是传入的键个数.
+  // 我们之传入了一个所以是O(1), 速度极快不需要加锁了
   async accessTokenAlive(
     token: string
   ){
@@ -183,7 +191,7 @@ export class TokenService {
 
   @WithLock({
     key(args){
-      return `lock:issueToken:${args[0]}`
+      return `user-token:${args[0]}`
     }
   })
   async issueToken(
@@ -219,7 +227,7 @@ export class TokenService {
   }
   @WithLock({
     key(args){
-      return `lock:getUserTokenCount:${args[0]}`
+      return `user-token:${args[0]}`
     }
   })
   async getUserTokenCount(
@@ -230,7 +238,7 @@ export class TokenService {
   }
   @WithLock({
     key(args){
-      return `lock:getTokenByJti:${args[0]}:${args[1]}:${args[2]}`
+      return `user-token:${args[0]}`
     }
   })
   async getTokenByJti(


### PR DESCRIPTION
- use shorter polling intervals to reduce idle waiting time for lock  release.
- Implement reentrant mechanism to support nested service calls and prevent dead locks
- Optimized for high-concurrency distributed environment

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: performance optimized

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request context tracking for per-request operations
  * Lock system now supports auto-renewal with configurable parameters
  * New refresh token revocation method for explicit token lifecycle management
  * Per-user token management and locking across authentication operations
  * Service discovery mechanism for dependency resolution at runtime

* **Bug Fixes**
  * Enhanced concurrent request handling with request-scoped identifiers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->